### PR TITLE
Fix message creation association

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -2,7 +2,8 @@ class MessagesController < ApplicationController
   before_action :authenticate_user!
 
   def create
-    @message = Message.new(message_params)
+    @conversation = Conversation.find(params[:conversation_id])
+    @message = @conversation.messages.new(message_params)
     @message.user = current_user
 
     if @message.save
@@ -15,6 +16,6 @@ class MessagesController < ApplicationController
   private
 
   def message_params
-    params.require(:message).permit(:body, :conversation_id)
+    params.require(:message).permit(:body)
   end
 end

--- a/test/controllers/messages_controller_test.rb
+++ b/test/controllers/messages_controller_test.rb
@@ -1,7 +1,20 @@
 require "test_helper"
 
 class MessagesControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
+  test "creates message associated with conversation" do
+    user = User.create!(email: "user1@example.com", password: "password")
+    recipient = User.create!(email: "user2@example.com", password: "password")
+    conversation = Conversation.create!(sender: user, recipient: recipient)
+
+    sign_in user
+
+    assert_difference("Message.count", 1) do
+      post conversation_messages_path(conversation), params: { message: { body: "Hello" } }
+    end
+
+    message = Message.order(:created_at).last
+    assert_equal conversation, message.conversation
+    assert_equal user, message.user
+    assert_redirected_to conversation_path(conversation)
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,4 +12,8 @@ module ActiveSupport
 
     # Add more helper methods to be used by all tests here...
   end
+
+  class ActionDispatch::IntegrationTest
+    include Devise::Test::IntegrationHelpers
+  end
 end


### PR DESCRIPTION
## Summary
- ensure messages are created under the correct conversation
- restrict message params to only :body
- add integration test for creating a message
- enable Devise helpers in integration tests

## Testing
- `bin/rails test` *(fails: Your Ruby version is 3.2.3, but your Gemfile specified 3.2.2)*

------
https://chatgpt.com/codex/tasks/task_e_684f57989e18833292f1f41048116eb7