### PR TITLE
Document Ruby requirement for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,4 +48,8 @@ Execute the test suite with:
 bin/rails test
 ```
 
-The tests use Minitest and run against the `test` database.
+The tests use Minitest and run against the `test` database. **Ruby 3.2.2 must be
+installed** to execute them successfully. If you are not using the provided
+Docker setup, install the required Ruby version with your preferred version
+manager (for example, `rbenv install 3.2.2`). The Dockerfile installs Ruby
+3.2.2 automatically when building the image.


### PR DESCRIPTION
## Summary
- update README to state Ruby 3.2.2 is needed to run tests
- mention installing via version manager or Dockerfile

## Testing
- `bin/rails test` *(fails: Ruby 3.2.2 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684f5ecae4088332bdb61e513e393850