### PR TITLE
Broadcast message partial HTML via ActionCable

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -7,10 +7,10 @@ class Message < ApplicationRecord
   private
 
   def broadcast_message
-    message_html = ApplicationController.render(
+    message_html = ApplicationController.renderer.render(
       partial: 'messages/message',
       locals: { message: self }
     )
-    ActionCable.server.broadcast("messages_#{conversation_id}", message_html)
+    ActionCable.server.broadcast("messages_#{conversation.id}", message_html)
   end
 end

--- a/test/channels/messages_channel_test.rb
+++ b/test/channels/messages_channel_test.rb
@@ -1,8 +1,21 @@
 require "test_helper"
 
 class MessagesChannelTest < ActionCable::Channel::TestCase
-  # test "subscribes" do
-  #   subscribe
-  #   assert subscription.confirmed?
-  # end
+  include ActionCable::TestHelper
+
+  test "broadcasts HTML when a message is created" do
+    sender = User.create!(email: "sender@example.com", password: "password", name: "Sender")
+    recipient = User.create!(email: "recipient@example.com", password: "password", name: "Recipient")
+    conversation = Conversation.create!(sender: sender, recipient: recipient)
+
+    message = Message.new(conversation: conversation, user: sender, body: "Hello")
+    expected_html = ApplicationController.renderer.render(
+      partial: "messages/message",
+      locals: { message: message }
+    )
+
+    assert_broadcast_on("messages_#{conversation.id}", expected_html) do
+      message.save!
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- send rendered message partial over ActionCable on creation
- verify broadcasted HTML in MessagesChannel tests

## Testing
- `bundle exec rake test` *(fails: ruby-3.2.2 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684f5ec9d03083328ca558107433192d